### PR TITLE
module should indicate if reboot needed to apply changes

### DIFF
--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -210,7 +210,7 @@ kernel_settings:
 """
 
 RETURN = """
-message:
+msg:
     A short text message to say what action this module performed.
 new_profile:
     This is the tuned profile in dict format, after the changes, if any,

--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -171,16 +171,16 @@ author:
 EXAMPLES = """
 # add the sysctl vm.max_mmap_regions, and disable spectre/meltdown security
 kernel_settings:
-    sysctl:
-      - name: vm.max_mmap_regions
-        value: 262144
-    sysfs:
-      - name: /sys/kernel/debug/x86/pti_enabled
-        value: 0
-      - name: /sys/kernel/debug/x86/retp_enabled
-        value: 0
-      - name: /sys/kernel/debug/x86/ibrs_enabled
-        value: 0
+  sysctl:
+    - name: vm.max_mmap_regions
+      value: 262144
+  sysfs:
+    - name: /sys/kernel/debug/x86/pti_enabled
+      value: 0
+    - name: /sys/kernel/debug/x86/retp_enabled
+      value: 0
+    - name: /sys/kernel/debug/x86/ibrs_enabled
+      value: 0
 
 # replace the existing sysctl section with the specified section
 # delete the /sys/kernel/debug/x86/retp_enabled setting
@@ -188,25 +188,36 @@ kernel_settings:
 # add the bootloader cmdline arguments spectre_v2=off nopti
 # remove the bootloader cmdline arguments quiet splash
 kernel_settings:
-    sysctl:
-      - previous: replaced
-      - name: vm.max_mmap_regions
-        value: 262144
-    sysfs:
-      - name: /sys/kernel/debug/x86/retp_enabled
-        state: absent
-    vm:
-      state: empty
-    bootloader:
-      - name: cmdline
-        value:
-          - name: spectre_v2
-            value: off
-          - name: nopti
-          - name: quiet
-            state: absent
-          - name: splash
-            state: absent
+  sysctl:
+    - previous: replaced
+    - name: vm.max_mmap_regions
+      value: 262144
+  sysfs:
+    - name: /sys/kernel/debug/x86/retp_enabled
+      state: absent
+  vm:
+    state: empty
+  bootloader:
+    - name: cmdline
+      value:
+        - name: spectre_v2
+          value: off
+        - name: nopti
+        - name: quiet
+          state: absent
+        - name: splash
+          state: absent
+"""
+
+RETURN = """
+message:
+    A short text message to say what action this module performed.
+new_profile:
+    This is the tuned profile in dict format, after the changes, if any,
+    have been applied.
+reboot_required:
+    boolean - default is false - if true, this means a reboot of the
+    managed host is required in order for the changes to take effect.
 """
 
 TUNED_PROFILE = os.environ.get("TEST_PROFILE", "kernel_settings")
@@ -370,11 +381,19 @@ def apply_item_to_profile(item, unitname, current_profile):
         ).options[name] = str(newvalue)
 
 
+def is_reboot_required(unitname):
+    """Some changes need a reboot for the changes to be applied
+       For example, bootloader cmdline changes"""
+    # for now, only bootloader cmdline changes need a reboot
+    return unitname == "bootloader"
+
+
 def apply_params_to_profile(params, current_profile, purge):
     """apply the settings from the input parameters to the current profile
     delete the unit if it is empty after applying the parameter deletions
     """
     changestatus = NOCHANGES
+    reboot_required = False
     section_to_replace = params.pop(SECTION_TO_REPLACE, {})
     need_purge = set()
     if purge:
@@ -395,6 +414,7 @@ def apply_params_to_profile(params, current_profile, purge):
                 if unit:
                     # we changed the profile
                     changestatus = CHANGES
+                reboot_required = reboot_required or is_reboot_required(unitname)
                 # we're done - no further processing necessary for this unit
                 continue
         for item in items:
@@ -405,14 +425,16 @@ def apply_params_to_profile(params, current_profile, purge):
             newoptions = current_profile.units[unitname].options
         if current_options != newoptions:
             changestatus = CHANGES
+            reboot_required = reboot_required or is_reboot_required(unitname)
     for unitname in need_purge:
         del current_profile.units[unitname]
         changestatus = CHANGES
+        reboot_required = reboot_required or is_reboot_required(unitname)
     # remove empty units
     for unitname in list(current_profile.units.keys()):
         if not current_profile.units[unitname].options:
             del current_profile.units[unitname]
-    return changestatus
+    return changestatus, reboot_required
 
 
 def write_profile(current_profile):
@@ -705,7 +727,7 @@ def run_module():
         # below
         module_args[plugin_name] = dict(type="raw", required=False)
 
-    result = dict(changed=False, original_message="", message="")
+    result = dict(changed=False, message="")
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
@@ -717,7 +739,7 @@ def run_module():
     # remove any non-tuned fields from params and save them locally
     # state = params.pop("state")
     purge = params.pop("purge", False)
-    paramname = params.pop("name")
+    del params["name"]
     # also remove any empty or None
     for key, val in list(params.items()):
         if not val:
@@ -749,19 +771,18 @@ def run_module():
         debug_print_profile(current_profile, module)
         errmsg = ""
 
-    # manipulate or modify the state as needed (this is going to be the
-    # part where your module will do what it needs to do)
-    result["original_message"] = paramname
-    result["message"] = "Kernel settings were updated"
+    result["msg"] = "Kernel settings were updated."
 
     # apply the given params to the profile - if there are any new items
     # the function will return True we set changed = True
-    changestatus = apply_params_to_profile(params, current_profile, purge)
+    changestatus, reboot_required = apply_params_to_profile(
+        params, current_profile, purge
+    )
     if update_current_profile_and_mode(tuned_app.daemon):
         # profile or mode changed
         if changestatus == NOCHANGES:
             changestatus = CHANGES
-            result["message"] = "Updated active profile and/or mode"
+            result["msg"] = "Updated active profile and/or mode."
     if changestatus > NOCHANGES:
         try:
             write_profile(current_profile)
@@ -776,10 +797,14 @@ def run_module():
             module.fail_json(msg=errmsg, **result)
         result["changed"] = True
     else:
-        result["message"] = "Kernel settings are up to date"
+        result["msg"] = "Kernel settings are up to date."
     debug_print_profile(current_profile, module)
     result["new_profile"] = profile_to_dict(current_profile)
-
+    result["reboot_required"] = reboot_required
+    if reboot_required:
+        result["msg"] = (
+            result["msg"] + "  A system reboot is needed to apply the changes."
+        )
     module.exit_json(**result)
 
 


### PR DESCRIPTION
Adds a new return value from the module `reboot_required` - this is
a boolean value, `false` by default.  If `true`, this means there
was a change made that will require rebooting the managed host in
order for the change to take effect.
I added a `RETURN` section to document the module return values.
I cleaned up the formatting of the examples and of the return
messages.