### PR TITLE
do not overwrite existing profile file

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
   template:
     src: "{{ __kernel_settings_profile_src }}.j2"
     dest: "{{ __kernel_settings_profile_filename }}"
+    force: no
     mode: 0644
 
 - name: Apply kernel settings


### PR DESCRIPTION
The role was overwriting the existing profile file.
Fixed by using the `template` module with `force: no` - if
the profile already exists, do not overwrite with the template