### PR TITLE
add NOTE about bootloader cmdline settings with Fedora Cloud images

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ and derivatives (RHEL and CentOS) and Fedora.
 
 * `tuned` homepage - https://github.com/redhat-performance/tuned
 
+Supported Distributions
+-----------------------
+* RHEL-7+, CentOS-7+
+* Fedora
+
+Limitations
+-----------
+
+### Fedora Cloud images - managing bootloader cmdline settings
+
+There is currently a problem with managing bootloader cmdline settings with
+Fedora Cloud images for Fedora 31, 32, and 33 rawhide.  We suggest you first
+update all of the packages (e.g. `dnf -y update`) and reboot the system before
+attempting to use `kernel_settings_bootloader_cmdline`.  And even then, it
+still might not work - the current Fedora 33 rawhide cloud images do not work
+even with the suggestion above.
+
 ## Requirements
 
 This role requires an operating system which has the `tuned` package and

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Supported Distributions
 Limitations
 -----------
 
+### Default bootloader settings cannot be removed/replaced
+
+This role cannot remove or replace bootloader cmdline options added by default.  For example, on a machine that you have not run the role on, check `cat /proc/cmdline`.  This role cannot remove those parameters.  In some cases it may be able to override them - see [kernel command-line parameters](https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html) for more information.  This role is used primarily to manage bootloader cmdline parameters related to performance and security.  It isn't meant as a general purpose bootloader management role.  If you need to manage the default bootloader cmdline settings, use the tools provided by your distribution like the `systemd-boot`, `grub2-*` and `grubby` tools.
+
 ### Fedora Cloud images - managing bootloader cmdline settings
 
 There is currently a problem with managing bootloader cmdline settings with


### PR DESCRIPTION
There are a couple of issues with bootloader cmdline settings.

* Cannot remove/replace default settings built-in to bootloader

* There is currently a problem with managing bootloader cmdline settings with
Fedora Cloud images for Fedora 31, 32, and 33 rawhide.