### PR TITLE
use panic instead of quiet in blcmd examples, tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,23 +203,25 @@ kernel_settings_bootloader_cmdline:
   - name: spectre_v2
     value: "off"
   - name: nopti
-  - name: quiet
+  - name: panic
+    value: 10001
   - name: splash
 ```
-will result in the values `spectre_v2=off nopti quiet splash` being added to,
-or replacing, the existing `bootloader` `cmdline` values.  If you want to
-remove whatever was there, and replace it with your specified values, use
-`previous: replaced` in the value list:
+will result in the values `spectre_v2=off nopti panic=10001 splash` being
+added to, or replacing, the existing `bootloader` `cmdline` values.  If you
+want to remove whatever was there, and replace it with your specified values,
+use `previous: replaced` in the value list:
 ```yaml
 kernel_settings_bootloader_cmdline:
   - previous: replaced
   - name: spectre_v2
     value: "off"
   - name: nopti
-  - name: quiet
+  - name: panic
+    value: 10001
   - name: splash
 ```
-then the values `spectre_v2=off nopti quiet splash` will *replace* the
+then the values `spectre_v2=off nopti panic=10001 splash` will *replace* the
 existing `cmdline` values, if any.  If you want to remove specific values, use
 `state: absent` on the settings you want to remove:
 ```yaml
@@ -229,9 +231,9 @@ kernel_settings_bootloader_cmdline:
   - name: nopti
     state: absent
 ```
-if the previous value was `spectre_v2=off nopti quiet splash`, the items
+if the previous value was `spectre_v2=off nopti panic=10001 splash`, the items
 `spectre_v2=off` and `nopti` will be removed from the list, and the final
-value will be `quiet splash`.
+value will be `panic=10001 splash`.
 
 ## Dependencies
 
@@ -262,7 +264,8 @@ The `tuned` package is required for the default provider.
       - name: spectre_v2
         value: "off"
       - name: nopti
-      - name: quiet
+      - name: panic
+        value: 10001
       - name: splash
   roles:
     - linux-system-roles.kernel_settings

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,7 +58,8 @@ kernel_settings_transparent_hugepages_defrag_state: null
 #   - name: spectre_v2
 #     value: "off"
 #   - name: nopti
-#   - name: quiet
+#   - name: panic
+#     value: 10001
 #   - name: splash
 kernel_settings_bootloader_cmdline: []
 

--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -186,7 +186,7 @@ kernel_settings:
 # delete the /sys/kernel/debug/x86/retp_enabled setting
 # completely remove the vm section
 # add the bootloader cmdline arguments spectre_v2=off nopti
-# remove the bootloader cmdline arguments quiet splash
+# remove the bootloader cmdline arguments panic splash
 kernel_settings:
   sysctl:
     - previous: replaced
@@ -203,7 +203,7 @@ kernel_settings:
         - name: spectre_v2
           value: off
         - name: nopti
-        - name: quiet
+        - name: panic
           state: absent
         - name: splash
           state: absent
@@ -320,7 +320,7 @@ class BLCmdLine(object):
     @classmethod
     def escapeval(cls, val):
         """make sure val is quoted as in shell"""
-        return shlex_quote(val)
+        return shlex_quote(str(val))
 
     def __str__(self):
         vallist = []

--- a/tests/tuned/etc/tuned/basic_settings/tuned.conf
+++ b/tests/tuned/etc/tuned/basic_settings/tuned.conf
@@ -21,4 +21,4 @@ vm.max_map_count=65530
 transparent_hugepages=never
 
 [bootloader]
-cmdline=spectre_v2=off nopti quiet splash
+cmdline=spectre_v2=off nopti panic=10001 splash

--- a/tests/unit/modules/test_kernel_settings.py
+++ b/tests/unit/modules/test_kernel_settings.py
@@ -307,7 +307,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
                     "value": [
                         {"name": "spectre_v2", "value": "off"},
                         {"name": "nopti"},
-                        {"name": "quiet"},
+                        {"name": "panic", "value": 10001},
                         {"name": "splash"},
                     ],
                 }
@@ -329,7 +329,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
         self.assertEqual(sysfs, dict(current_profile.units["sysfs"].options))
         vm = {"transparent_hugepages": "never"}
         self.assertEqual(vm, current_profile.units["vm"].options)
-        cmdline = {"cmdline": "spectre_v2=off nopti quiet splash"}
+        cmdline = {"cmdline": "spectre_v2=off nopti panic=10001 splash"}
         self.assertEqual(cmdline, dict(current_profile.units["bootloader"].options))
         self.assertTrue(reboot_required)
         # test idempotency
@@ -359,7 +359,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
                         {"name": "someother", "value": "value"},
                         {"name": "spectre_v2", "value": "off"},
                         {"name": "nopti"},
-                        {"name": "quiet", "state": "absent"},
+                        {"name": "panic", "state": "absent"},
                         {"name": "splash", "state": "absent"},
                     ],
                 }
@@ -404,7 +404,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
                     "value": [
                         {"name": "spectre_v2", "value": "off"},
                         {"name": "nopti"},
-                        {"name": "quiet"},
+                        {"name": "panic", "value": 10001},
                         {"name": "splash"},
                     ],
                 }
@@ -425,7 +425,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
         sysfs = {"/sys/kernel/debug/x86/pti_enabled": "0"}
         self.assertEqual(sysfs, dict(current_profile.units["sysfs"].options))
         self.assertNotIn("vm", current_profile.units)
-        cmdline = {"cmdline": "spectre_v2=off nopti quiet splash"}
+        cmdline = {"cmdline": "spectre_v2=off nopti panic=10001 splash"}
         self.assertEqual(cmdline, dict(current_profile.units["bootloader"].options))
         self.assertFalse(reboot_required)
         # test idempotency
@@ -447,7 +447,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
                     "value": [
                         {"name": "spectre_v2", "value": "off"},
                         {"name": "nopti"},
-                        {"name": "quiet"},
+                        {"name": "panic", "value": 10001},
                         {"name": "splash"},
                     ],
                 }
@@ -479,7 +479,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
             "[vm]",
             "transparent_hugepages = never",
             "[bootloader]",
-            "cmdline = spectre_v2=off nopti quiet splash",
+            "cmdline = spectre_v2=off nopti panic=10001 splash",
         ]
         expected = ConfigObj(expected_lines)
         actual = None

--- a/tests/vars/vars_simple_settings.yml
+++ b/tests/vars/vars_simple_settings.yml
@@ -24,9 +24,11 @@ kernel_settings_bootloader_cmdline:
   - name: nopti
   - name: notfound
     state: absent
+  - name: panic
+    value: 10001
 
 # this is the expected value of the bootloader cmdline file
-__kernel_settings_blcmdline_value: "spectre_v2=off nopti"
+__kernel_settings_blcmdline_value: "spectre_v2=off nopti panic=10001"
 
 # set true if the change should cause the role to set the reboot flag
 __kernel_settings_check_reboot: true


### PR DESCRIPTION
Some of the systems we use for testing have `quiet` as a built-in
bootloader cmdline value.  The kernel_settings role cannot remove
or replace built-in values.  Instead, use `panic` with a value
of `10001` as it is seldom used and applicable to all platforms.
This also gives us a non-string value to use for testing.
There was a bug with using non-string values in blcmdline
values.  This commit also fixes that bug.