### PR TITLE
replace bootloader cmdline bool values with on/off

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,21 @@ if the previous value was `spectre_v2=off nopti panic=10001 splash`, the items
 `spectre_v2=off` and `nopti` will be removed from the list, and the final
 value will be `panic=10001 splash`.
 
+**NOTE**: Use either string values or numeric values to avoid ambiguity or errors with boolean values.  For example, a value like `value: on` will be converted to the string value `"True"` in the stored configuration, since `on` is a YAML boolean value for `True`.  Instead, use `value: "on"` to mean the actual string `"on"`. For bootloader cmdline values, since `on` and `off` are commonly used
+for boolean values, the role will convert a YAML boolean value to `"on"` or `"off"`. For example, if you passed
+```yaml
+ kernel_settings_bootloader_cmdline:
+  - name: spectre_v2
+    value: true
+```
+the role will convert this to `spectre_v2=on`.  But better to use
+```yaml
+ kernel_settings_bootloader_cmdline:
+  - name: spectre_v2
+    value: "on"
+```
+to avoid any errors or ambiguity.
+
 ## Dependencies
 
 The `tuned` package is required for the default provider.

--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -336,6 +336,10 @@ class BLCmdLine(object):
         """add/replace the given key & value"""
         if key not in self.key_to_val:
             self.key_list.append(key)
+        if val is True:
+            val = "on"
+        elif val is False:
+            val = "off"
         self.key_to_val[key] = val
 
     def remove(self, key):

--- a/tests/unit/modules/test_kernel_settings.py
+++ b/tests/unit/modules/test_kernel_settings.py
@@ -101,6 +101,11 @@ class KernelSettingsBootloaderCmdline(unittest.TestCase):
         blcmd.add("foo", "false")
         self.assertEqual("foo=false another", str(blcmd))
 
+        blcmd = kernel_settings.BLCmdLine("")
+        blcmd.add("foo", True)
+        blcmd.add("bar", False)
+        self.assertEqual("foo=on bar=off", str(blcmd))
+
 
 class KernelSettingsInputValidation(unittest.TestCase):
     """test the code that does the input validation"""

--- a/tests/vars/vars_simple_settings.yml
+++ b/tests/vars/vars_simple_settings.yml
@@ -20,7 +20,7 @@ kernel_settings_transparent_hugepages_defrag_state: absent
 
 kernel_settings_bootloader_cmdline:
   - name: spectre_v2
-    value: "off"
+    value: off
   - name: nopti
   - name: notfound
     state: absent


### PR DESCRIPTION
The use of `on` and `off` for bootloader cmdline values is
quite common - https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html

Even though we will strongly encourage users to use a YAML string
value for bootloader cmdline settings, it will help users avoid
mistakes if we convert YAML boolean values to `"on"`/`"off"`.

For example, if the user types in this instead of `value: "on"`:
```yaml
kernel_settings_bootloader_cmdline:
  - name: someparam
    value: on
```
we will convert this to `someparam=on`.  This also means values
like:
```yaml
kernel_settings_bootloader_cmdline:
  - name: someparam
    value: true
```
will also be converted to `someparam=on`.