### PR TITLE
use SPDX-License-Identifier: GPL-2.0-or-later instead of GPLv2+

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Some files are licensed under GPLv2+.  These files have the text
 
-    SPDX-License-Identifier: GPLv2+
+    SPDX-License-Identifier: GPL-2.0-or-later
 
 in the file header.
 

--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2020, Rich Megginson <rmeggins@redhat.com>
-# SPDX-License-Identifier: GPLv2+
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 """ Manage kernel settings using tuned via a wrapper """
 

--- a/tests/unit/modules/test_kernel_settings.py
+++ b/tests/unit/modules/test_kernel_settings.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2020, Rich Megginson <rmeggins@redhat.com>
-# SPDX-License-Identifier: GPLv2+
+# SPDX-License-Identifier: GPL-2.0-or-later
 #
 """ Unit tests for kernel_settings module """
 


### PR DESCRIPTION
@pcahyna @nhosoi please review