### PR TITLE
do not use omit - does not work on nested values with ansible 2.7

### DIFF
--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -723,6 +723,24 @@ def validate_and_digest(params):
     return errlist
 
 
+def remove_if_empty(params):
+    """recursively remove empty items from params
+       return true if params results in being empty,
+       false otherwise"""
+    if isinstance(params, list):
+        removed = 0
+        for idx in range(0, len(params)):
+            realidx = idx - removed
+            if remove_if_empty(params[realidx]):
+                del params[realidx]
+                removed = removed + 1
+    elif isinstance(params, dict):
+        for key, val in list(params.items()):
+            if remove_if_empty(val):
+                del params[key]
+    return params == [] or params == {} or params == "" or params is None
+
+
 def run_module():
     """ The entry point of the module. """
 
@@ -750,9 +768,7 @@ def run_module():
     purge = params.pop("purge", False)
     del params["name"]
     # also remove any empty or None
-    for key, val in list(params.items()):
-        if not val:
-            del params[key]
+    _ = remove_if_empty(params)
     errlist = validate_and_digest(params)
     if errlist:
         errmsg = "Invalid format for input parameters"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,41 +41,34 @@
       - name: "{{ 'cpu_affinity'
                   if kernel_settings_systemd_cpu_affinity
                   or kernel_settings_systemd_cpu_affinity_state
-                  else omit }}"
-        value: "{{ kernel_settings_systemd_cpu_affinity
-                   if kernel_settings_systemd_cpu_affinity
-                   else omit }}"
-        state: "{{ kernel_settings_systemd_cpu_affinity_state
-                   if kernel_settings_systemd_cpu_affinity_state
-                   else omit }}"
+                  else none }}"
+        value: "{{ kernel_settings_systemd_cpu_affinity |
+                   d(none, true) }}"
+        state: "{{ kernel_settings_systemd_cpu_affinity_state |
+                   d(none, true) }}"
     vm:
       - name: "{{ 'transparent_hugepages'
                   if kernel_settings_transparent_hugepages
                   or kernel_settings_transparent_hugepages_state
-                  else omit }}"
-        value: "{{ kernel_settings_transparent_hugepages
-                   if kernel_settings_transparent_hugepages
-                   else omit }}"
-        state: "{{ kernel_settings_transparent_hugepages_state
-                   if kernel_settings_transparent_hugepages_state
-                   else omit }}"
+                  else none }}"
+        value: "{{ kernel_settings_transparent_hugepages |
+                   d(none, true) }}"
+        state: "{{ kernel_settings_transparent_hugepages_state |
+                   d(none, true) }}"
       - name: "{{ 'transparent_hugepage.defrag'
                   if kernel_settings_transparent_hugepages_defrag
                   or kernel_settings_transparent_hugepages_defrag_state
-                  else omit }}"
-        value: "{{ kernel_settings_transparent_hugepages_defrag
-                   if kernel_settings_transparent_hugepages_defrag
-                   else omit }}"
-        state: "{{ kernel_settings_transparent_hugepages_defrag_state
-                   if kernel_settings_transparent_hugepages_defrag_state
-                   else omit }}"
+                  else none }}"
+        value: "{{ kernel_settings_transparent_hugepages_defrag |
+                   d(none, true) }}"
+        state: "{{ kernel_settings_transparent_hugepages_defrag_state |
+                   d(none, true) }}"
     bootloader:
       - name: "{{ 'cmdline'
                   if kernel_settings_bootloader_cmdline | d({})
-                  else omit }}"
-        value: "{{ kernel_settings_bootloader_cmdline
-                   if kernel_settings_bootloader_cmdline | d({})
-                   else omit }}"
+                  else none }}"
+        value: "{{ kernel_settings_bootloader_cmdline |
+                   d([]) }}"
     purge: "{{ kernel_settings_purge }}"
   notify: __kernel_settings_handler_modified
   register: __kernel_settings_register_module

--- a/tests/unit/modules/test_kernel_settings.py
+++ b/tests/unit/modules/test_kernel_settings.py
@@ -499,5 +499,67 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
         self.assertEqual(expected.initial_comment, actual.initial_comment)
 
 
+class KernelSettingsRemoveIfEmpty(unittest.TestCase):
+    """test remove_if_empty"""
+
+    def test_remove_if_empty(self):
+        """test remove_if_empty"""
+        params = {}
+        self.assertTrue(kernel_settings.remove_if_empty(params))
+        self.assertEqual({}, params)
+        params = {"key1": "", "key2": [], "key3": {}, "key4": None}
+        self.assertTrue(kernel_settings.remove_if_empty(params))
+        self.assertEqual({}, params)
+        params = ["", [], {}, None]
+        self.assertTrue(kernel_settings.remove_if_empty(params))
+        self.assertEqual([], params)
+        params = {"key1": "", "key2": [], "key3": {}, "key4": None, "key5": 0}
+        self.assertFalse(kernel_settings.remove_if_empty(params))
+        self.assertEqual({"key5": 0}, params)
+        params = [1, "", 2, [], 3, {}, 4, None, 5]
+        self.assertFalse(kernel_settings.remove_if_empty(params))
+        self.assertEqual([1, 2, 3, 4, 5], params)
+        params = 0
+        self.assertFalse(kernel_settings.remove_if_empty(params))
+        self.assertEqual(0, params)
+        params = {"key1": [{"key2": [{"key3": 3}]}]}
+        self.assertFalse(kernel_settings.remove_if_empty(params))
+        self.assertEqual({"key1": [{"key2": [{"key3": 3}]}]}, params)
+        params = {"key1": [{"key2": [{"key3": 3}, {"key4": ""}]}]}
+        self.assertFalse(kernel_settings.remove_if_empty(params))
+        self.assertEqual({"key1": [{"key2": [{"key3": 3}]}]}, params)
+        params = {
+            "key11": None,
+            "key1": [
+                "",
+                {"key2": [{"key3": []}, {"key4": ""}, {"key5": None}, {"key6": {}}]},
+            ],
+        }
+        self.assertTrue(kernel_settings.remove_if_empty(params))
+        self.assertEqual({}, params)
+        params = [
+            None,
+            {"key11": None},
+            {
+                "key1": [
+                    "",
+                    {
+                        "key2": [
+                            {"key3": []},
+                            {"key4": ""},
+                            {"key5": None},
+                            {"key6": {}},
+                        ]
+                    },
+                ]
+            },
+            [],
+            {},
+            "",
+        ]
+        self.assertTrue(kernel_settings.remove_if_empty(params))
+        self.assertEqual([], params)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The use of `omit` with second level or lower values does not
work on ansible 2.7.  The keys are passed to the module with
the value `__omit_token_xxxx`.  Instead, use the value `none`
or some other value which is empty appropriate for the key being
set, and have the module strip all empty values.