### PR TITLE
RHELPLAN-46757 - bug with current implementation of platform/version …

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,18 @@
 ---
 - name: Set version specific variables
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "{{ ansible_distribution }}_{{ ansible_distribution_version }}.yml"
-    - "{{ ansible_distribution }}_{{ ansible_distribution_major_version }}.yml"
-    - "{{ ansible_distribution }}.yml"
-    - "{{ ansible_os_family }}.yml"
-    - "default.yml"
+  include_vars: "{{ lookup('first_found', ffparams) }}"
+  vars:
+    ffparams:
+      files:
+        - "{{ ansible_facts['distribution'] }}_\
+          {{ ansible_facts['distribution_version'] }}.yml"
+        - "{{ ansible_facts['distribution'] }}_\
+          {{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
+        - "default.yml"
+      paths:
+        - "{{ role_path }}/vars"
 
 - name: Ensure required packages are installed
   package:

--- a/tests/tasks/assert_kernel_settings.yml
+++ b/tests/tasks/assert_kernel_settings.yml
@@ -1,10 +1,14 @@
 ---
-- name: Set variables used by assert/testing code
-  include_vars: "{{ item }}"
-  with_first_found:
-    - "vars/tests_{{ ansible_distribution }}_\
-      {{ ansible_distribution_major_version }}.yml"
-    - "vars/tests_default.yml"
+- name: Set version specific variables
+  include_vars: "{{ lookup('first_found', ffparams) }}"
+  vars:
+    ffparams:
+      files:
+        - "tests_{{ ansible_distribution }}_\
+          {{ ansible_distribution_major_version }}.yml"
+        - "tests_default.yml"
+      paths:
+        - vars
 
 - name: reset settings success flag
   set_fact:


### PR DESCRIPTION
…specific vars/tasks file include/import

Updated based on the oasis-roles meta_standards:
  Supporting multiple distributions and versions
  - Always specify the explicit, absolute path to the files to be included
  - Using loop instead of with_first_found.