### PR TITLE
use import_role instead of include_vars for role vars

### DIFF
--- a/tests/tests_simple_settings.yml
+++ b/tests/tests_simple_settings.yml
@@ -17,9 +17,13 @@
       include_role:
         name: linux-system-roles.kernel_settings
 
-    - name: include vars from role to use for verification
-      include_vars:
-        file: roles/linux-system-roles.kernel_settings/vars/main.yml
+    # NOTE: This is only to include the vars from vars/main.yml - the
+    # when: false will skip all of the tasks in the role except the
+    # implicit tasks to load the vars and defaults
+    - name: import the role to include vars to use for verification
+      import_role:
+        name: linux-system-roles.kernel_settings
+      when: false
 
     - name: verify that settings were applied correctly
       include_tasks: tasks/assert_kernel_settings.yml


### PR DESCRIPTION
The test verification needs access to the role private vars from
vars/main.yml.  Using include_vars requires a path which may be
different depending on the packaging.  Instead, rely on a "trick"
with import_role - using `when: false` will include the role, skipping
the explicit tasks, but running the implicit tasks such as loading
the vars and defaults.