### PR TITLE
use include_role with public: true to get role vars

### DIFF
--- a/tests/tests_simple_settings.yml
+++ b/tests/tests_simple_settings.yml
@@ -13,17 +13,14 @@
         __kernel_settings_check_reboot: false
       when: ansible_distribution == "Fedora"
 
+    # use public: true here so that the private role
+    # variables will be exported - we use
+    # __kernel_settings_profile_filename to verify
+    # that the settings were applied correctly
     - name: apply the settings - call the role
       include_role:
         name: linux-system-roles.kernel_settings
-
-    # NOTE: This is only to include the vars from vars/main.yml - the
-    # when: false will skip all of the tasks in the role except the
-    # implicit tasks to load the vars and defaults
-    - name: import the role to include vars to use for verification
-      import_role:
-        name: linux-system-roles.kernel_settings
-      when: false
+        public: true
 
     - name: verify that settings were applied correctly
       include_tasks: tasks/assert_kernel_settings.yml


### PR DESCRIPTION
The test playbook needs the role private vars to verify the settings.
use include_role with `public: true` so that those vars will be
exported and available to the tests
@nhosoi @pcahyna