### PR TITLE
Lock ansible-lint on version 4.2.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -108,6 +108,7 @@ commands =
 [molecule_common]
 changedir = {toxinidir}
 deps =
+    ansible-lint==4.2.0
     {env:LSR_ANSIBLE_DEP:ansible}
     docker
     molecule<3


### PR DESCRIPTION
`ansible-lint` 4.2.0 is latest known version of `ansible-lint` that does not break CI testing with `tox` & Travis