### PR TITLE
install_tuned_for_testing.sh - supporting the collection path.

### DIFF
--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -87,7 +87,10 @@ function ks_lsr_install_tuned() {
   pip install --upgrade pip setuptools wheel
   # extra requirements for tuned
   pip install -r "$TOPDIR/tuned_requirements.txt"
-  bash "$TOPDIR/tests/install_tuned_for_testing.sh" "$(ks_lsr_get_site_packages_dir)" "$tunedver"
+  if [ -x "$TOPDIR/tests/install_tuned_for_testing.sh" ]; then
+    bash "$TOPDIR/tests/install_tuned_for_testing.sh" "$(ks_lsr_get_site_packages_dir)" "$tunedver"
+  elif [ -x "$TOPDIR/tests/kernel_settings/install_tuned_for_testing.sh" ]; then
+    bash "$TOPDIR/tests/kernel_settings/install_tuned_for_testing.sh" "$(ks_lsr_get_site_packages_dir)" "$tunedver"
 }
 
 # install tuned only where needed


### PR DESCRIPTION
@richm, could it be possible to add this type of logic for the collections format to make tox/travis tests run?