### PR TITLE
RHELPLAN-56580 - sync collections related changes from template to kernel_settings role

### DIFF
--- a/.travis/config.sh
+++ b/.travis/config.sh
@@ -87,7 +87,11 @@ function ks_lsr_install_tuned() {
   pip install --upgrade pip setuptools wheel
   # extra requirements for tuned
   pip install -r "$TOPDIR/tuned_requirements.txt"
-  bash "$TOPDIR/tests/install_tuned_for_testing.sh" "$(ks_lsr_get_site_packages_dir)" "$tunedver"
+  if [ -f "$TOPDIR/tests/install_tuned_for_testing.sh" ]; then
+    bash "$TOPDIR/tests/install_tuned_for_testing.sh" "$(ks_lsr_get_site_packages_dir)" "$tunedver"
+  elif [ -f "$TOPDIR/tests/kernel_settings/install_tuned_for_testing.sh" ]; then
+    bash "$TOPDIR/tests/kernel_settings/install_tuned_for_testing.sh" "$(ks_lsr_get_site_packages_dir)" "$tunedver"
+  fi
 }
 
 # install tuned only where needed

--- a/.travis/runcollection.sh
+++ b/.travis/runcollection.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# SPDX-License-Identifier: MIT
+
+set -e
+
+#uncomment if you use $ME - otherwise set in utils.sh
+#ME=$(basename "$0")
+SCRIPTDIR=$(readlink -f "$(dirname "$0")")
+
+. "${SCRIPTDIR}/utils.sh"
+. "${SCRIPTDIR}/config.sh"
+
+# Collection commands that are run when `tox -e collection`:
+role=$(basename "${TOPDIR}")
+toxworkdir=${1:-"${TOPDIR}"/.tox}
+STABLE_TAG=${2:-master}
+cd "${toxworkdir}"
+toxworkdir=$(pwd)
+envlist=${3:- "black,flake8,yamllint,py38,shellcheck"}
+automaintenancerepo=https://raw.githubusercontent.com/linux-system-roles/auto-maintenance/
+
+curl -L -o lsr_role2collection.py "${automaintenancerepo}${STABLE_TAG}"/lsr_role2collection.py
+
+python lsr_role2collection.py --src-path "${TOPDIR}/.." --dest-path "${toxworkdir}" --role "${role}" > "${toxworkdir}"/collection.out 2>&1
+
+yamllint="${toxworkdir}"/ansible_collections/fedora/system_roles/.yamllint_defaults.yml
+sed -i -e 's/\( *\)\(document-start: disable\)/\1\2\n\1line-length:\n\1\1level: warning/' "${yamllint}"
+
+cd ansible_collections/fedora/system_roles
+tox -e "${envlist}" 2>&1 | tee "${toxworkdir}"/collection.tox.out || :
+
+rm -rf "${toxworkdir}"/auto-maintenance "${toxworkdir}"/ansible_collections
+cd "${TOPDIR}"
+res=$(grep "^ERROR: .*failed" "${toxworkdir}"/collection.tox.out || :)
+if [ "$res" != "" ]; then
+    lsr_error "${ME}: tox in the converted collection format failed."
+    exit 1
+fi

--- a/.travis/utils.sh
+++ b/.travis/utils.sh
@@ -172,6 +172,21 @@ function lsr_venv_python_matches_system_python() {
   lsr_compare_pythons "${1:-python}" -eq "$syspython"
 }
 
+function run_setup_module_utils() {
+  local srcdir
+  srcdir="$1"
+  local destdir
+  destdir="$2"
+  if [ -x "$TOPDIR/tests/setup_module_utils.sh" ]; then
+    bash "$TOPDIR/tests/setup_module_utils.sh" "$srcdir" "$destdir"
+  else
+    setup_module_util=$( find "$TOPDIR"/tests -name "setup_module_utils.sh" | head -n 1 )
+    if [ "$setup_module_util" != "" ]; then
+      bash "$setup_module_util" "$srcdir" "$destdir"
+    fi
+  fi
+}
+
 ##
 # lsr_setup_module_utils [$1] [$2]
 #
@@ -189,7 +204,16 @@ function lsr_setup_module_utils() {
   local destdir
   destdir="${2:-$DEST_MODULE_UTILS_DIR}"
   if [ -n "$srcdir" ] && [ -d "$srcdir" ] && [ -n "$destdir" ] && [ -d "$destdir" ]; then
-    bash "$TOPDIR/tests/setup_module_utils.sh" "$srcdir" "$destdir"
+    run_setup_module_utils "$srcdir" "$destdir"
+  else
+    srcdir="${SRC_COLL_MODULE_UTILS_DIR}"
+    destdir="${DEST_COLL_MODULE_UTILS_DIR}"
+    if [ -n "$destdir" ] && [ -d "$destdir" ]; then
+      if [ -n "$srcdir" ] && [ ! -d "$srcdir" ]; then
+        mkdir -p "$srcdir"
+      fi
+      run_setup_module_utils "$srcdir" "$destdir"
+    fi
   fi
 }
 

--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -390,7 +390,7 @@ def apply_item_to_profile(item, unitname, current_profile):
 
 def is_reboot_required(unitname):
     """Some changes need a reboot for the changes to be applied
-       For example, bootloader cmdline changes"""
+    For example, bootloader cmdline changes"""
     # for now, only bootloader cmdline changes need a reboot
     return unitname == "bootloader"
 
@@ -725,8 +725,8 @@ def validate_and_digest(params):
 
 def remove_if_empty(params):
     """recursively remove empty items from params
-       return true if params results in being empty,
-       false otherwise"""
+    return true if params results in being empty,
+    false otherwise"""
     if isinstance(params, list):
         removed = 0
         for idx in range(0, len(params)):

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@
 envlist =
     black, pylint, flake8, yamllint
     py{26,27,36,37,38}, shellcheck
-    custom
+    collection, custom
 skipsdist = true
 skip_missing_interpreters = true
 
@@ -164,6 +164,16 @@ commands =
     {[testenv:molecule_syntax]commands}
     {[testenv:molecule_test]commands}
 
+[testenv:collection]
+changedir = {toxinidir}
+ansible_python_interpreter = /usr/bin/python3
+deps =
+    ruamel.yaml
+    ansible
+    jmespath
+commands =
+    bash {toxinidir}/.travis/runcollection.sh {toxworkdir} master
+
 [testenv:custom]
 changedir = {toxinidir}
 envdir = {toxworkdir}/env-{env:TRAVIS_PYTHON_VERSION:custom}
@@ -184,7 +194,7 @@ addopts = -rxs
 [flake8]
 show_source = true
 max-line-length = 88
-ignore = E402,W503
+ignore = E402,W503,E501
 exclude = .venv,.tox
 statistics = true
 #verbose = 3
@@ -200,7 +210,7 @@ max-line-length = 88
 python =
   2.6: py26,coveralls,custom
   2.7: py27,coveralls,flake8,pylint,custom
-  3.6: py36,coveralls,black,yamllint,shellcheck,custom
+  3.6: py36,coveralls,black,yamllint,shellcheck,custom,collection
   3.7: py37,coveralls,custom
   3.8: py38,coveralls,custom
   3.8-dev: py38,coveralls,custom


### PR DESCRIPTION
- Adding .travis/runcollection.sh.
- Enabling collection as part of tox/travis tests.
- Fixing a black error in library/kernel_settings.py.
- Supporting the collections test path in .travis/config.sh.
  "$TOPDIR/tests/kernel_settings/install_tuned_for_testing.sh"