### PR TITLE
use tox for ansible-lint instead of molecule

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
           27) toxenvs="${toxenvs},coveralls,flake8,pylint,custom" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck,custom,collection" ;;
+          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection" ;;
           37) toxenvs="${toxenvs},coveralls,custom" ;;
           38) toxenvs="${toxenvs},coveralls,custom" ;;
           esac

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,6 +6,7 @@ driver:
   name: docker
 lint:
   name: yamllint
+  enabled: false
   options:
     config-file: .yamllint.yml
 platforms:
@@ -18,6 +19,7 @@ provisioner:
   name: ansible
   log: true
   lint:
+    enabled: false
     name: ansible-lint
   playbooks:
     converge: ../../tests/tests_default.yml
@@ -34,3 +36,4 @@ verifier:
   name: testinfra
   lint:
     name: flake8
+    enabled: false


### PR DESCRIPTION
Deprecate the use of molecule for linting.  Use tox for ansible-lint.
The next step will be to remove the ansible-lint dependency from
the molecule environments.