### PR TITLE
make tuned.conf have correct ansible_managed comment

### DIFF
--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -83,11 +83,16 @@ options:
               the given settings to be the current and only settings
         type: bool
         default: false
-    ansible_managed:
+    ansible_managed_new:
         description:
             - Ansible ansible_managed string to put in header of file
             - should be in the format of {{ ansible_managed | comment }}
             - as rendered by the template module
+        type: str
+        required: true
+    ansible_managed_current:
+        description:
+            - the current config file header to be compared and replaced
         type: str
         required: true
 
@@ -493,17 +498,17 @@ def apply_params_to_profile(params, current_profile, purge):
     return changestatus, reboot_required
 
 
-def write_profile(current_profile, ansible_managed):
+def write_profile(current_profile, ansible_managed_new):
     """write the profile to the profile file"""
     # convert profile to configobj to write ini-style file
     # profile.options go into [main] section
     # profile.units go into [unitname] section
     cfg = configobj.ConfigObj(indent_type="")
-    # ansible_managed should be in the format of
-    # ansible_managed passed through the comment filter
+    # ansible_managed_new should be in the format of
+    # ansible_managed_new passed through the comment filter
     # as rendered by the ansible "template" module - strip the
     # trailing newline, if any
-    cfg.initial_comment = ansible_managed.strip().split("\n")
+    cfg.initial_comment = ansible_managed_new.strip().split("\n")
     cfg["main"] = current_profile.options
     for unitname, unit in current_profile.units.items():
         cfg[unitname] = unit.options
@@ -805,7 +810,11 @@ def run_module():
         # use raw here - type can be dict or list - perform validation
         # below
         module_args[plugin_name] = dict(type="raw", required=False)
-    module_args["ansible_managed"] = dict(
+    module_args["ansible_managed_new"] = dict(
+        type="str",
+        required=True,
+    )
+    module_args["ansible_managed_current"] = dict(
         type="str",
         required=True,
     )
@@ -823,7 +832,8 @@ def run_module():
     # remove any non-tuned fields from params and save them locally
     # state = params.pop("state")
     purge = params.pop("purge", False)
-    ansible_managed = params.pop("ansible_managed")
+    ansible_managed_new = params.pop("ansible_managed_new")
+    ansible_managed_current = params.pop("ansible_managed_current")
     # also remove any empty or None
     # pylint: disable=blacklisted-name
     _ = remove_if_empty(params)
@@ -867,9 +877,12 @@ def run_module():
         if changestatus == NOCHANGES:
             changestatus = CHANGES
             result["msg"] = "Updated active profile and/or mode."
+    if changestatus == NOCHANGES and ansible_managed_new != ansible_managed_current:
+        changestatus = CHANGES
+        result["msg"] = "Updated ansible_managed."
     if changestatus > NOCHANGES:
         try:
-            write_profile(current_profile, ansible_managed)
+            write_profile(current_profile, ansible_managed_new)
             # notify tuned to reload/reapply profile
         except TunedException as tex:
             module.debug("caught TunedException [{0}]".format(tex))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,12 @@
     force: no
     mode: 0644
 
+- name: Get current config
+  slurp:
+    src: "{{ __kernel_settings_profile_filename }}"
+  register: __kernel_settings_profile_contents_b64
+  changed_when: false
+
 - name: Apply kernel settings
   kernel_settings:
     sysctl: "{{ kernel_settings_sysctl if kernel_settings_sysctl else omit }}"
@@ -76,7 +82,8 @@
         value: "{{ kernel_settings_bootloader_cmdline |
                    d([]) }}"
     purge: "{{ kernel_settings_purge }}"
-    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
+    ansible_managed_new: "{{ __kernel_settings_new_header }}"
+    ansible_managed_current: "{{ __kernel_settings_cur_header }}"
   notify: __kernel_settings_handler_modified
   register: __kernel_settings_register_module
   when:
@@ -86,6 +93,13 @@
       or kernel_settings_transparent_hugepages_defrag
       or kernel_settings_bootloader_cmdline | d({})
       or kernel_settings_purge
+      or __kernel_settings_cur_header != __kernel_settings_new_header
+  vars:
+    __kernel_settings_cur_header: "{{
+      __kernel_settings_profile_contents_b64.content | b64decode |
+      regex_replace('(?sm)^\\[.*$', '') }}"
+    __kernel_settings_new_header: "{{
+      lookup('template', 'get_ansible_managed.j2') }}"
 
 - name: tuned apply settings
   command: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,6 +76,7 @@
         value: "{{ kernel_settings_bootloader_cmdline |
                    d([]) }}"
     purge: "{{ kernel_settings_purge }}"
+    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"
   notify: __kernel_settings_handler_modified
   register: __kernel_settings_register_module
   when:

--- a/templates/get_ansible_managed.j2
+++ b/templates/get_ansible_managed.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed | comment }}

--- a/tests/tests_simple_settings.yml
+++ b/tests/tests_simple_settings.yml
@@ -44,3 +44,7 @@
       when:
         - kernel_settings_reboot_required | d(false)
         - not kernel_settings_test_reboot_ok | d(false)
+
+    - name: show contents of tuned.conf
+      command: cat /etc/tuned/kernel_settings/tuned.conf
+      changed_when: false

--- a/tests/unit/modules/test_kernel_settings.py
+++ b/tests/unit/modules/test_kernel_settings.py
@@ -484,12 +484,17 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
         )
         self.assertEqual(kernel_settings.CHANGES, changestatus)
         self.assertTrue(reboot_required)
-        kernel_settings.write_profile(current_profile)
+        kernel_settings.write_profile(
+            current_profile,
+            "# one\n# two\n# three\n",
+        )
         fname = os.path.join(
             tuned.consts.LOAD_DIRECTORIES[-1], "kernel_settings", "tuned.conf"
         )
         expected_lines = [
-            "# File managed by Ansible - DO NOT EDIT",
+            "# one",
+            "# two",
+            "# three",
             "[main]",
             "summary = kernel settings",
             "[sysctl]",


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2044640
The kernel_settings role needs to generate the tuned.conf with the
correct `ansible_managed` string commented in the same format as
generated by the template module.  The only way to do this is to
invoke the template module via a lookup with an actual template
file.