### PR TITLE
ensure python-configobj is present

### DIFF
--- a/vars/CentOS_7.yml
+++ b/vars/CentOS_7.yml
@@ -1,0 +1,3 @@
+---
+__kernel_settings_packages: ["tuned", "python-configobj"]
+__kernel_settings_services: ["tuned"]

--- a/vars/RedHat_7.yml
+++ b/vars/RedHat_7.yml
@@ -1,0 +1,3 @@
+---
+__kernel_settings_packages: ["tuned", "python-configobj"]
+__kernel_settings_services: ["tuned"]

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,3 +1,3 @@
 ---
-__kernel_settings_packages: ["tuned"]
+__kernel_settings_packages: ["tuned", "python3-configobj"]
 __kernel_settings_services: ["tuned"]


### PR DESCRIPTION
tuned recently switched from configobj to configparser.  The role cannot
yet switch to use configparser.  Ensure that the package python-configobj
is present.
