### PR TITLE
add sysctl for testing - package procps-ng

### DIFF
--- a/tests/tests_change_settings.yml
+++ b/tests/tests_change_settings.yml
@@ -1,8 +1,9 @@
 - hosts: all
   tasks:
+    # procps-ng for sysctl cmd
     - name: Ensure required packages are installed
       package:
-        name: tuned
+        name: [tuned, procps-ng]
         state: present
 
     - name: Ensure kernel settings profile directory exists


### PR DESCRIPTION
Looks like rhel 8.6 dropped `procps-ng` recently, so no `sysctl` command for test playbooks - add it back