### PR TITLE
support gather_facts: false; support setup-snapshot.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,6 @@
 ---
 - name: Set version specific variables
-  include_vars: "{{ lookup('first_found', ffparams) }}"
-  vars:
-    ffparams:
-      files:
-        - "{{ ansible_facts['distribution'] }}_\
-          {{ ansible_facts['distribution_version'] }}.yml"
-        - "{{ ansible_facts['distribution'] }}_\
-          {{ ansible_facts['distribution_major_version'] }}.yml"
-        - "{{ ansible_facts['distribution'] }}.yml"
-        - "{{ ansible_facts['os_family'] }}.yml"
-        - "default.yml"
-      paths:
-        - "{{ role_path }}/vars"
+  include_tasks: set_vars.yml
 
 - name: Ensure required packages are installed
   package:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,22 @@
+---
+- name: Ensure ansible_facts used by role
+  setup:
+    gather_subset: min
+  when: not ansible_facts.keys() | list |
+    intersect(__kernel_settings_required_facts) ==
+    __kernel_settings_required_facts
+
+- name: Set platform/version specific variables
+  include_vars: "{{ lookup('first_found', ffparams) }}"
+  vars:
+    ffparams:
+      files:
+        - "{{ ansible_facts['distribution'] }}_\
+          {{ ansible_facts['distribution_version'] }}.yml"
+        - "{{ ansible_facts['distribution'] }}_\
+          {{ ansible_facts['distribution_major_version'] }}.yml"
+        - "{{ ansible_facts['distribution'] }}.yml"
+        - "{{ ansible_facts['os_family'] }}.yml"
+        - "default.yml"
+      paths:
+        - "{{ role_path }}/vars"

--- a/tests/setup-snapshot.yml
+++ b/tests/setup-snapshot.yml
@@ -1,0 +1,12 @@
+- hosts: all
+  tasks:
+    - name: Set platform/version specific variables
+      include_role:
+        name: linux-system-roles.kernel_settings
+        tasks_from: set_vars.yml
+        public: true
+
+    - name: Install test packages
+      package:
+        name: "{{ __kernel_settings_packages }}"
+        state: present

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,5 +1,6 @@
 ---
 - name: Ensure that the role runs with default parameters
   hosts: all
+  gather_facts: false
   roles:
     - linux-system-roles.kernel_settings

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,3 +6,10 @@ __kernel_settings_profile_filename: >-
   {{ __kernel_settings_profile_dir }}/tuned.conf
 __kernel_settings_state_absent:
   state: absent
+
+# ansible_facts required by the role
+__kernel_settings_required_facts:
+  - distribution
+  - distribution_major_version
+  - distribution_version
+  - os_family


### PR DESCRIPTION
Some users use `gather_facts: false` in their playbooks.  This changes
the role to work in that case, by gathering only the facts it requires
to run.
CI testing can be sped up by creating a snapshot image pre-installed
with packages.  tests/setup-snapshot.yml can be used by a CI system
to do this.
