### PR TITLE
Version 1.1.9 - CHANGELOG.md [citest skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Changelog
 =========
 
+[1.1.9] - 2022-07-09
+--------------------
+
+### New Features
+
+- none
+
+### Bug Fixes
+
+- none
+
+### Other Changes
+
+- make all tests work with gather_facts: false (#82)
+
+Ensure tests work when using ANSIBLE_GATHERING=explicit
+
+-  make min_ansible_version a string in meta/main.yml (#83)
+
+The Ansible developers say that `min_ansible_version` in meta/main.yml
+must be a `string` value like `"2.9"`, not a `float` value like `2.9`.
+
+- Add CHANGELOG.md (#84)
+
 [1.1.8] - 2022-05-06
 --------------------
 


### PR DESCRIPTION
[1.1.9] - 2022-07-09
--------------------

REMOVE_ME: Recommend to itemize the change log entries in one of the following sections.
REMOVE_ME: Use Other Changes for CI, testing, and other non-feature/non-bug related items.
### New Features
### Bug Fixes
### Other Changes
- make all tests work with gather_facts: false (#82)

Ensure tests work when using ANSIBLE_GATHERING=explicit
- [citest skip] make min_ansible_version a string in meta/main.yml (#83)

The Ansible developers say that `min_ansible_version` in meta/main.yml
must be a `string` value like `"2.9"`, not a `float` value like `2.9`.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
- Add CHANGELOG.md (#84)

- [citest skip] Modify CHANGELOG.md (#85)

- Replace the ATX style with the setext style for the header H1 and H2.
- Each changelog has 3 sections, "### New Features", "### Bug Fixes",
  and "Other Changes".
- If there is no items in a section, let it have "- none".

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
