### PR TITLE
Add check for non-inclusive language

### DIFF
--- a/.github/workflows/woke.yml
+++ b/.github/workflows/woke.yml
@@ -1,0 +1,18 @@
+# yamllint disable rule:line-length
+name: Check for non-inclusive language
+on:  # yamllint disable-line rule:truthy
+  - pull_request
+jobs:
+  woke:
+    name: woke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: woke
+        uses: get-woke/woke-action@v0
+        with:
+          woke-args: "-c https://raw.githubusercontent.com/linux-system-roles/tox-lsr/main/src/tox_lsr/config_files/woke.yml"
+          # Cause the check to fail on any broke rules
+          fail-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,11 @@ if the user has set `kernel_settings_reboot_ok: true`.
 
 Fix a bash bug in changelog_to_tag.yml, which unexpectedly expanded "*".
 
-- changelog_to_tag action - support other than "master" for the main branch name, as well (#92)
+- changelog_to_tag action - github action ansible test improvements (#92)
 
 - Use GITHUB_REF_NAME as name of push branch; fix error in branch detection [citest skip] (#94)
 
 We need to get the name of the branch to which CHANGELOG.md was pushed.
-For now, it looks as though `GITHUB_REF_NAME` is that name.  But don't
-trust it - first, check that it is `main` or `master`.  If not, then use
-a couple of other methods to determine what is the push branch.
 
 Signed-off-by: Rich Megginson <rmeggins@redhat.com>
 
@@ -222,14 +219,14 @@ must be a `string` value like `"2.9"`, not a `float` value like `2.9`.
 
 ### Bug Fixes
 
-- Fix ansible-test sanity issues 
+- Fix ansible-test issues 
 - Fix issues found by ansible-test and linters - enable all tests on all repos - remove suppressions 
 - kernel\_settings.py - must be quoted 
 
 ### Other Changes
 
 - use tuned 2.15 for unit tests 
-- update to tox-lsr 2.4.0 - add support for ansible-test sanity with docker 
+- update to tox-lsr 2.4.0 - add support for ansible-test with docker 
 - CI: Add support for RHEL-9 
 - Add a note to each module Doc to indicate it is private 
 

--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -212,7 +212,7 @@ import ansible.module_utils.six.moves as ansible_six_moves
 
 from ansible.module_utils.basic import AnsibleModule
 
-# see https://github.com/python/cpython/blob/master/Lib/logging/__init__.py
+# see https://github.com/python/cpython/blob/main/Lib/logging/__init__.py
 # for information about logging module internals
 
 
@@ -371,6 +371,7 @@ class BLCmdLine(object):
     @classmethod
     def splititem(cls, item):
         """split item in form key=somevalue into key and somevalue"""
+        # wokeignore:rule=blacklist
         # pylint: disable=blacklisted-name
         key, _, val = item.partition("=")
         return key, val
@@ -825,6 +826,7 @@ def run_module():
 
     if not module.check_mode:
         if os.environ.get("TESTING", "false") == "true":
+            # wokeignore:rule=blacklist
             # pylint: disable=blacklisted-name
             _ = setup_for_testing()
 
@@ -835,6 +837,7 @@ def run_module():
     ansible_managed_new = params.pop("ansible_managed_new")
     ansible_managed_current = params.pop("ansible_managed_current")
     # also remove any empty or None
+    # wokeignore:rule=blacklist
     # pylint: disable=blacklisted-name
     _ = remove_if_empty(params)
     errlist = validate_and_digest(params)

--- a/tests/unit/modules/test_kernel_settings.py
+++ b/tests/unit/modules/test_kernel_settings.py
@@ -290,12 +290,14 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
         )
         self.assertIsNone(tuned_app)
         self.assertRegex(errmsg, "Error loading tuned profile")
+        # wokeignore:rule=blacklist
         # pylint: disable=blacklisted-name
         tuned_app, _ = kernel_settings.load_current_profile(
             self.tuned_config, "kernel_settings", self.logger
         )
         self.assertEqual("kernel settings", tuned_app.daemon.profile.options["summary"])
         self.assertEqual(0, len(tuned_app.daemon.profile.units))
+        # wokeignore:rule=blacklist
         # pylint: disable=blacklisted-name
         tuned_app, _ = kernel_settings.load_current_profile(
             self.tuned_config, "basic_settings", self.logger
@@ -329,6 +331,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
                 }
             ],
         }
+        # wokeignore:rule=blacklist
         # pylint: disable=blacklisted-name
         tuned_app, _ = kernel_settings.load_current_profile(
             self.tuned_config, "kernel_settings", self.logger
@@ -383,6 +386,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
             ],
         }
         paramsorig = copy.deepcopy(params)
+        # wokeignore:rule=blacklist
         # pylint: disable=blacklisted-name
         tuned_app, _ = kernel_settings.load_current_profile(
             self.tuned_config, "basic_settings", self.logger
@@ -428,6 +432,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
                 }
             ],
         }
+        # wokeignore:rule=blacklist
         # pylint: disable=blacklisted-name
         tuned_app, _ = kernel_settings.load_current_profile(
             self.tuned_config, "basic_settings", self.logger
@@ -474,6 +479,7 @@ class KernelSettingsParamsProfiles(unittest.TestCase):
         }
         errlist = kernel_settings.validate_and_digest(params)
         self.assertEqual(len(errlist), 0)
+        # wokeignore:rule=blacklist
         # pylint: disable=blacklisted-name
         tuned_app, _ = kernel_settings.load_current_profile(
             self.tuned_config, "kernel_settings", self.logger


### PR DESCRIPTION
Add a check for usage of terms and language that is considered
non-inclusive. We are using the woke tool for this with a wordlist
that can be found at
https://github.com/linux-system-roles/tox-lsr/blob/main/src/tox_lsr/config_files/woke.yml

Clean up non-inclusive words.
- CHANGELOG.md
- library/kernel_settings.py
- tests/unit/modules/test_kernel_settings.py