### PR TITLE
Fix issues found by CodeQL

### DIFF
--- a/library/kernel_settings.py
+++ b/library/kernel_settings.py
@@ -625,9 +625,6 @@ def setup_for_testing():
     pyudev.monitor.Monitor.set_receive_buffer_size = lambda self, size: None
 
     def test_cleanup():
-        import os
-        import shutil
-
         if "TEST_ROOT_DIR" not in os.environ:
             shutil.rmtree(test_root_dir)
         for cnst, val in orig_consts.items():


### PR DESCRIPTION
library/kernel_settings.py
- This import of module os is redundant, as it was previously imported [on line 191](1).
- This import of module os is redundant, as it was previously imported [on line 195](1).

Signed-off-by: Noriko Hosoi <nhosoi@redhat.com>