### PR TITLE
ansible-lint - use changed_when even if using conditional

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,6 +93,7 @@
   command: >
     tuned-adm profile '{{ __kernel_settings_register_module.active_profile }}'
   when: __kernel_settings_register_module is changed  # noqa no-handler
+  changed_when: true
 
 - name: Verify settings
   include_tasks: verify_settings.yml

--- a/tasks/verify_settings.yml
+++ b/tasks/verify_settings.yml
@@ -18,6 +18,7 @@
       grep 'ERROR    tuned.plugins' || :
   register: __kernel_settings_register_verify_log
   when: __kernel_settings_register_verify_values is failed
+  changed_when: false
 
 - name: Report errors that are not bootloader errors
   fail:

--- a/tests/tasks/assert_kernel_settings.yml
+++ b/tests/tasks/assert_kernel_settings.yml
@@ -19,18 +19,21 @@
   register: __kernel_settings_register_verify
   ignore_errors: true
   when: __kernel_settings_test_verify
+  changed_when: false
 
 - name: Check for verify errors
   command: tail /var/log/tuned/tuned.log
   when:
     - __kernel_settings_register_verify is defined
     - __kernel_settings_register_verify is failed
+  changed_when: false
 
 - name: Check /proc/cmdline
   command: cat /proc/cmdline
   when:
     - __kernel_settings_register_verify is defined
     - __kernel_settings_register_verify is failed
+  changed_when: false
 
 - name: Set error flag based on verify
   set_fact:

--- a/tests/tasks/assert_kernel_settings_conf_files.yml
+++ b/tests/tasks/assert_kernel_settings_conf_files.yml
@@ -40,6 +40,7 @@
     {{ __kernel_settings_profile_filename }}
   ignore_errors: true  # noqa ignore-errors
   when: __kernel_settings_register_profile_conf_result is failed
+  changed_when: false
 
 - name: Get active_profile file
   slurp:
@@ -78,6 +79,7 @@
   register: __kernel_settings_register_verify_bl_cmdline
   when:
     - __kernel_settings_blcmdline_value | d()
+  changed_when: false
 
 - name: Verify bootloader settings value
   set_fact:


### PR DESCRIPTION
ansible-lint now requires the use of `changed_when` even if the
command already uses `when`

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
