### PR TITLE
test: check generated files for ansible_managed, fingerprint

### DIFF
--- a/tests/tasks/check_header.yml
+++ b/tests/tasks/check_header.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+---
+- name: Get file
+  slurp:
+    path: "{{ __file }}"
+  register: __content
+  when: not __file_content is defined
+
+- name: Check for presence of ansible managed header, fingerprint
+  assert:
+    that:
+      - ansible_managed in content
+      - __fingerprint in content
+  vars:
+    content: "{{ (__file_content | d(__content)).content | b64decode }}"
+    ansible_managed: "{{ lookup('template', 'get_ansible_managed.j2') }}"

--- a/tests/templates/get_ansible_managed.j2
+++ b/tests/templates/get_ansible_managed.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed | comment(__comment_type | d("plain")) }}

--- a/tests/tests_simple_settings.yml
+++ b/tests/tests_simple_settings.yml
@@ -30,6 +30,12 @@
       vars:
         __kernel_settings_test_verify: false
 
+    - name: Check ansible_managed, fingerprint in generated files
+      include_tasks: tasks/check_header.yml
+      vars:
+        __file: "{{ __kernel_settings_profile_filename }}"
+        __fingerprint: "system_role:kernel_settings"
+
     # reboot if a reboot is needed AND we did not tell the role
     # to reboot the machine if needed
     - name: Reboot the machine - see if settings persist after reboot


### PR DESCRIPTION
Add the following files: tests/tasks/check_header.yml and
tests/templates/get_ansible_managed.j2.
Use check_header.yml to check generated files for the ansible_managed
and fingerprint headers.
check_header.yml takes these parameters.  `fingerprint` is required,
and one of `__file` or `__file_content`:

* `__file` - the full path of the file to check e.g. `/etc/realmd.conf`
* `__file_content` - the output of `slurp` of the file
* `__fingerprint` - required - the fingerprint string `system_role:$ROLENAME` e.g.
  `__fingerprint: "system_role:postfix"`
* `__comment_type` - optional, default `plain` - the type of comments used

e.g. `__comment_type: c` for C/C++-style comments.  `plain` uses `#`.
See https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_filters.html#adding-comments-to-files
for the different types of comment styles supported.

Example:
```
- name: Check generated files for ansible_managed, fingerprint
  include_tasks: tasks/check_header.yml
  vars:
    __file: /etc/myfile.conf
    __fingerprint: "system_role:my_role"
```
