### PR TITLE
ci: run ansible-lint against the collection

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -53,7 +53,8 @@ jobs:
               cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
             fi
           done
-          rm -rf .git
+          rm -rf .git .ansible-lint
+          mkdir "$coll_dir/.git"
 
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@v6

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Convert role to collection format
         run: |
           set -euxo pipefail
-          echo "verbosity: 10" >> .ansible-lint
           TOXENV=collection lsr_ci_runtox
           # copy the ignore files
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
@@ -54,8 +53,10 @@ jobs:
             fi
           done
           rm -rf .git .ansible-lint *
+          cp "$coll_dir/.ansible-lint" .ansible-lint
           mv .tox/ansible_collections .
           rm -rf .tox
+          echo "verbosity: 10" >> .ansible-lint
 
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@v6

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -53,10 +53,11 @@ jobs:
               cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
             fi
           done
-          rm -rf .git .ansible-lint
-          mkdir "$coll_dir/.git"
+          rm -rf .git .ansible-lint *
+          mv .tox/ansible_collections .
+          rm -rf .tox
 
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@v6
         with:
-          path: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          path: ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -53,9 +53,9 @@ jobs:
               cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
             fi
           done
+          rm -rf .git
 
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@v6
         with:
           path: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
-          args: "--project_dir .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Convert role to collection format
         run: |
           set -euxo pipefail
-          echo "verbosity=10" >> .ansible-lint
+          echo "verbosity: 10" >> .ansible-lint
           TOXENV=collection lsr_ci_runtox
           # copy the ignore files
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -52,8 +52,7 @@ jobs:
               cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
             fi
           done
-          rm -rf .git .ansible-lint *
-          cp "$coll_dir/.ansible-lint" .ansible-lint
+          rm -rf .git *
           mv .tox/ansible_collections .
           rm -rf .tox
           echo "verbosity: 10" >> .ansible-lint

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -11,6 +11,9 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
   workflow_dispatch:
+env:
+  LSR_ROLE2COLL_NAMESPACE: fedora
+  LSR_ROLE2COLL_NAME: linux_system_roles
 permissions:
   contents: read
 jobs:
@@ -26,18 +29,31 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Fix up role meta/main.yml namespace and name
+      - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          mm=meta/main.yml
-          if [ -f "$mm" ]; then
-            if ! grep -q '^  *namespace:' "$mm"; then
-              sed "/galaxy_info:/a\  namespace: linux_system_roles" -i "$mm"
-            fi
-            if ! grep -q '^  *role_name:' "$mm"; then
-              sed "/galaxy_info:/a\  role_name: kernel_settings" -i "$mm"
-            fi
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.0.0"
+
+      - name: Convert role to collection format
+        run: |
+          set -euxo pipefail
+          TOXENV=collection lsr_ci_runtox
+          # copy the ignore files
+          coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+          # wokeignore:rule=sanity
+          ignore_dir="$coll_dir/tests/sanity"
+          if [ ! -d "$ignore_dir" ]; then
+            mkdir -p "$ignore_dir"
           fi
+          # wokeignore:rule=sanity
+          for file in .sanity-ansible-ignore-*.txt; do
+            if [ -f "$file" ]; then
+              # wokeignore:rule=sanity
+              cp "$file" "$ignore_dir/${file//*.sanity-ansible-}"
+            fi
+          done
 
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@v6
+        with:
+          path: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -58,3 +58,4 @@ jobs:
         uses: ansible-community/ansible-lint-action@v6
         with:
           path: .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}
+          args: "--project_dir .tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}"

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -37,6 +37,7 @@ jobs:
       - name: Convert role to collection format
         run: |
           set -euxo pipefail
+          echo "verbosity=10" >> .ansible-lint
           TOXENV=collection lsr_ci_runtox
           # copy the ignore files
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"


### PR DESCRIPTION
The latest Ansible repo gating tests run ansible-lint against
the collection format instead of against individual roles.
We have to convert the role to collection format before running
ansible-test.

Role developers can run this locally using
`tox -e collection,ansible-lint-collection`
See https://github.com/linux-system-roles/tox-lsr/pull/125

ha_cluster - add to python_roles

metrics - fix ansible-lint

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
