### PR TITLE
ci: Fix implicit octal values in main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,14 +18,14 @@
   file:
     path: "{{ __kernel_settings_profile_dir }}"
     state: directory
-    mode: 0755
+    mode: "0755"
 
 - name: Generate a configuration for kernel settings
   template:
     src: "{{ __kernel_settings_profile_src }}.j2"
     dest: "{{ __kernel_settings_profile_filename }}"
     force: false
-    mode: 0644
+    mode: "0644"
 
 - name: Get current config
   slurp:


### PR DESCRIPTION
Enhancement:

Reason: Forbidden implicit octal values "0755", and "0644" were found on lines 21,28.

Result: Updated to use explicit octal format for better readability and to adhere to linting standards.

Issue Tracker Tickets (Jira or BZ if any):na