### PR TITLE
ci: Add ALP-Dolomite var file

### DIFF
--- a/vars/ALP-Dolomite
+++ b/vars/ALP-Dolomite
@@ -1,0 +1,3 @@
+---
+__kernel_settings_packages: ["tuned", "python-configobj"]
+__kernel_settings_services: ["tuned"]

--- a/vars/ALP-Dolomite.yml
+++ b/vars/ALP-Dolomite.yml
@@ -1,0 +1,3 @@
+---
+__kernel_settings_packages: ["tuned", "python-configobj"]
+__kernel_settings_services: ["tuned"]


### PR DESCRIPTION
Enhancement: Add variables for additional operating system.

Reason: The existing configuration does not cover [SUSE ALP](https://documentation.suse.com/alp/dolomite/html/alp-dolomite/index.html), the default configurations are being used.

Result: Works as expected in the added operating system.

Issue Tracker Tickets (Jira or BZ if any):na