### PR TITLE
ci: use tox-lsr 3.3.1 which fixes py27 and related unit tests

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.1"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -37,11 +37,14 @@ jobs:
       - name: Convert role to collection format
         run: |
           set -euxo pipefail
-          TOXENV=collection lsr_ci_runtox
+          ls -al /usr/bin/python3
+          tox -vvv -e collection
+          #TOXENV=collection lsr_ci_runtox
           coll_dir=".tox/ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
           # ansible-lint action requires a .git directory???
           # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
           mkdir -p "$coll_dir/.git"
+          ls -al "$coll_dir"
 
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v24

--- a/.github/workflows/ansible-managed-var-comment.yml
+++ b/.github/workflows/ansible-managed-var-comment.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-plugin-scan.yml
+++ b/.github/workflows/ansible-plugin-scan.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.1"
 
       - name: Run ansible-plugin-scan
         run: |

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install tox, tox-lsr
         run: |
           set -euxo pipefail
-          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip3 install "git+https://github.com/linux-system-roles/tox-lsr@3.3.1"
 
       - name: Convert role to collection format
         run: |

--- a/.github/workflows/python-unit-test.yml
+++ b/.github/workflows/python-unit-test.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           set -euxo pipefail
           python -m pip install --upgrade pip
-          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.3.0"
+          pip install "git+https://github.com/linux-system-roles/tox-lsr@3.3.1"
           # If you have additional OS dependency packages e.g. libcairo2-dev
           # then put them in .github/config/ubuntu-requirements.txt, one
           # package per line.

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: MIT
+[tox]
+requires = virtualenv
+skip_missing_interpreters = false
+
 [lsr_config]
 lsr_enable = true
 commands_pre = bash -c '\


### PR DESCRIPTION
The latest version of virtualenv does not support creating
python 2.7 virtualenvs.  tox-lsr 3.3.1 restricts the version
of virtualenv<20.22.0

This PR also fixes some py unit test, pylint, and related
issues caused by using the latest versions of those tools.

For more information, see
https://github.com/linux-system-roles/tox-lsr/pull/168

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
