### PR TITLE
ci: Add tft plan and workflow

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -172,5 +172,6 @@ jobs:
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: ${{ job.status }}
-          targetUrl: ${{ env.ARTIFACTS_URL }}
           context: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
+          description: Test finished
+          targetUrl: ${{ env.ARTIFACTS_URL }}


### PR DESCRIPTION
This change is for running tests in Testing Farm CI. This is a replacement for
BaseOS CI that we are currently using. Running it Testing Farm gives us more
control.

It adds a workflow for running tests, and a plans directory containing a test
plan and a README-plans.md with some info.

Note that this workflow runs from the main branch. This means that changes to
the workflow must be merged to main, then pull requests will be able to run it.
This is because the workflow uses on: issue_comment context, this is a security
measure recommended by GitHub. It saves us from leaking organization secrets.

The functionality is WIP, so await future fixes and updates.

Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
