### PR TITLE
ci: Improve tft plan and workflow

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -172,5 +172,6 @@ jobs:
         with:
           sha: ${{ needs.prepare_vars.outputs.head_sha }}
           status: ${{ job.status }}
-          targetUrl: ${{ env.ARTIFACTS_URL }}
           context: ${{ matrix.platform }}|ansible-${{ matrix.ansible_version }}
+          description: Test finished
+          targetUrl: ${{ env.ARTIFACTS_URL }}

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -1,4 +1,4 @@
-name: Testing Farm
+name: Run integration tests in Testing Farm
 on:
   issue_comment:
     types:
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   prepare_vars:
-    name: Get supported platforms from meta/main.yml
+    name: Get info from role and PR to determine if and how to test
     # Let's schedule tests only on user request. NOT automatically.
     # Only repository owner or member can schedule tests
     if: |
@@ -136,7 +136,8 @@ jobs:
           description: The role does not support this platform. Skipping.
           targetUrl: ""
 
-      - uses: sclorg/testing-farm-as-github-action@v2
+      - name: Run test in testing farm
+        uses: sclorg/testing-farm-as-github-action@v2
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         env:
           ARTIFACTS_DIR: ${{ env.ARTIFACT_TARGET_DIR }}/${{ env.ARTIFACTS_DIR_NAME }}


### PR DESCRIPTION
This change is for running tests in Testing Farm CI. This is a replacement for
BaseOS CI that we are currently using. Running it Testing Farm gives us more
control.

It adds a workflow for running tests, and a plans directory containing a test
plan and a README-plans.md with some info.

Note that this workflow runs from the main branch. This means that changes to
the workflow must be merged to main, then pull requests will be able to run it.
This is because the workflow uses on: issue_comment context, this is a security
measure recommended by GitHub. It saves us from leaking organization secrets.

The functionality is WIP, so await future fixes and updates.

Signed-off-by: Sergei Petrosian <spetrosi@redhat.com>
