### PR TITLE
ci: Handle reboot for transactional update systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,15 @@ when to reboot the managed host.  The role will return the variable
 `kernel_settings_reboot_required` (see below) with a value of `true` to indicate
 that some change has occurred which needs a reboot to take effect.
 
+### kernel_settings_transactional_update_reboot_ok
+
+This variable is used to handle reboots required by transactional updates.
+If a transactional update requires a reboot, the role will proceed with the
+reboot if `kernel_settings_transactional_update_reboot_ok` is set to `true`. If set
+to `false`, the role will notify the user that a reboot is required, allowing
+for custom handling of the reboot requirement. If this variable is not set,
+the role will fail to ensure the reboot requirement is not overlooked.
+
 ### Variables Exported by the Role
 
 The role will export the following variables:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -47,3 +47,11 @@ kernel_settings_purge: false
 # some changes will require the managed host to be rebooted in order to be
 # applied, and will set kernel_settings_reboot_required: true
 kernel_settings_reboot_ok: false
+
+# This variable is used to handle reboots required by transactional updates.
+# If a transactional update requires a reboot, the role will proceed with the
+# reboot if `kernel_settings_transactional_update_reboot_ok` is set to `true`. If set
+# to `false`, the role will notify the user that a reboot is required, allowing
+# for custom handling of the reboot requirement. If this variable is not set,
+# the role will fail to ensure the reboot requirement is not overlooked.
+kernel_settings_transactional_update_reboot_ok: null

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,30 @@
     state: present
     use: "{{ (__kernel_settings_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
+  register: kernel_settings_package_result
+
+- name: Handle reboot for transactional update systems
+  when:
+    - __kernel_settings_is_transactional | d(false)
+    - kernel_settings_package_result is changed
+  block:
+    - name: Notify user that reboot is needed to apply changes
+      debug:
+        msg: >
+          Reboot required to apply changes due to transactional updates.
+
+    - name: Reboot transactional update systems
+      reboot:
+        msg: Rebooting the system to apply transactional update changes.
+      when: kernel_settings_transactional_update_reboot_ok | bool
+
+    - name: Fail if reboot is needed and not set
+      fail:
+        msg: >
+          Reboot is required but not allowed. Please set
+          'kernel_settings_transactional_update_reboot_ok' to proceed.
+      when:
+        - kernel_settings_transactional_update_reboot_ok is none
 
 - name: Ensure required services are enabled and started
   service:

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -17,6 +17,18 @@
       set_fact:
         __kernel_settings_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if system is transactional update and set flag
+  when: not __kernel_settings_is_transactional is defined
+  block:
+    - name: Check if transactional-update exists in /sbin
+      stat:
+        path: /sbin/transactional-update
+      register: __transactional_update_stat
+
+    - name: Set flag if transactional-update exists
+      set_fact:
+        __kernel_settings_is_transactional: "{{ __transactional_update_stat.stat.exists }}"
+
 - name: Set platform/version specific variables
   include_vars: "{{ lookup('first_found', ffparams) }}"
   vars:

--- a/tests/vars/tests_SL-Micro.yml
+++ b/tests/vars/tests_SL-Micro.yml
@@ -1,0 +1,3 @@
+---
+__kernel_settings_test_python_pkgs: ["python", "python-configobj"]
+__kernel_settings_test_python_cmd: python3

--- a/vars/ALP-Dolomite
+++ b/vars/ALP-Dolomite
@@ -1,3 +1,0 @@
----
-__kernel_settings_packages: ["tuned", "python-configobj"]
-__kernel_settings_services: ["tuned"]

--- a/vars/ALP-Dolomite.yml
+++ b/vars/ALP-Dolomite.yml
@@ -1,3 +1,0 @@
----
-__kernel_settings_packages: ["tuned", "python-configobj"]
-__kernel_settings_services: ["tuned"]


### PR DESCRIPTION
Enhancement: - Added a block to identify and handle reboots for transactional update systems on package changes. Update README. Remove ALP-Dolomite var as it is no longer used.

Reason: Ensure necessary reboots are managed, as changes on transactional update systems are applied in a separate snapshot and require a reboot to take effect.

Result: Manages system reboots for transactional update systems when a package is installed.

Issue Tracker Tickets (Jira or BZ if any):na
