### PR TITLE
ci: ansible-test action now requires ansible-core version

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -44,4 +44,5 @@ jobs:
         uses: ansible-community/ansible-test-gh-action@release/v1
         with:
           testing-type: sanity  # wokeignore:rule=sanity
+          ansible-core-version: stable-2.17
           collection-src-directory: ${{ github.workspace }}/.tox/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -157,8 +157,8 @@ jobs:
         uses: sclorg/testing-farm-as-github-action@v3
         if: contains(needs.prepare_vars.outputs.supported_platforms, matrix.platform)
         with:
-          git_url: https://github.com/richm/linux-system-roles-tft-tests
-          git_ref: get_python_modules
+          git_url: https://github.com/linux-system-roles/tft-tests
+          git_ref: main
           pipeline_settings: '{ "type": "tmt-multihost" }'
           environment_settings: '{ "provisioning": { "tags": { "BusinessUnit": "system_roles" } } }'
           # Keeping ARTIFACTS_URL at the bottom makes the link in logs clickable
@@ -169,8 +169,7 @@ jobs:
             ARTIFACTS_DIR=${{ steps.set_vars.outputs.ARTIFACTS_DIR }};\
             TEST_LOCAL_CHANGES=false;\
             LINUXSYSTEMROLES_USER=${{ vars.LINUXSYSTEMROLES_USER }};\
-            ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }};\
-            GET_PYTHON_MODULES=${{ contains(github.event.comment.body, 'GET_PYTHON_MODULES') }}"
+            ARTIFACTS_URL=${{ steps.set_vars.outputs.ARTIFACTS_URL }}"
           # Note that LINUXSYSTEMROLES_SSH_KEY must be single-line, TF doesn't read multi-line variables fine.
           secrets: "LINUXSYSTEMROLES_DOMAIN=${{ secrets.LINUXSYSTEMROLES_DOMAIN }};\
             LINUXSYSTEMROLES_SSH_KEY=${{ secrets.LINUXSYSTEMROLES_SSH_KEY }}"


### PR DESCRIPTION
The ansible-test github action does not use a supported version
of ansible-core by default.
https://github.com/ansible-community/ansible-test-gh-action?tab=readme-ov-file#ansible-core-version

We have to set it in our action.  Using `stable-2.17` as that is the latest stable version.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
