### PR TITLE
refactor: disable ansible-lint invalid jinja error

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,6 +92,8 @@
 
 - name: Set active_profile
   set_fact:
+    # not really invalid - see https://github.com/ansible/ansible-lint/issues/4702
+    # noqa jinja[invalid]
     __kernel_settings_active_profile: "{{ __cur_profile
       if __kernel_settings_tuned_profile in __cur_profile
       else __cur_profile ~ ' ' ~ __kernel_settings_tuned_profile }}"


### PR DESCRIPTION
Not really invalid
see https://github.com/ansible/ansible-lint/issues/4702

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Enhancements:
- Add noqa jinja[invalid] comment to disable ansible-lint invalid jinja warning for the __kernel_settings_active_profile set_fact