### PR TITLE
ci: fix markdown formatting for contributing.md to pass markdownlint

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -134,6 +134,7 @@ Where `args.json` looks like this:
     }
 }
 ```
+
 ## Running CI Tests Locally
 
 ### Use tox-lsr with qemu


### PR DESCRIPTION
fix markdown formatting for contributing.md to pass markdownlint

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Documentation:
- Add a blank line before the "Running CI Tests Locally" heading to comply with markdownlint rules