### PR TITLE
ci: Ansible version must be string, not float [citest_skip]

### DIFF
--- a/.github/workflows/tft.yml
+++ b/.github/workflows/tft.yml
@@ -98,21 +98,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Ensure ansible version is a string!
           - platform: Fedora-42
-            ansible_version: 2.19
+            ansible_version: "2.19"
           - platform: Fedora-43
-            ansible_version: 2.20
+            ansible_version: "2.20"
           - platform: CentOS-7-latest
-            ansible_version: 2.9
+            ansible_version: "2.9"
           - platform: CentOS-Stream-8
-            ansible_version: 2.9
+            ansible_version: "2.9"
           # On CentOS-Stream-8, latest supported Ansible is 2.16
           - platform: CentOS-Stream-8
-            ansible_version: 2.16
+            ansible_version: "2.16"
           - platform: CentOS-Stream-9
-            ansible_version: 2.17
+            ansible_version: "2.17"
           - platform: CentOS-Stream-10
-            ansible_version: 2.17
+            ansible_version: "2.17"
     runs-on: ubuntu-latest
     env:
       ARTIFACTS_DIR_NAME: "tf_${{ github.event.repository.name }}-${{ github.event.issue.number }}_\

--- a/plans/test_playbooks_parallel.fmf
+++ b/plans/test_playbooks_parallel.fmf
@@ -10,9 +10,10 @@ provision:
   - name: managed-node2
     role: managed_node
 environment:
-  SR_ANSIBLE_VER: 2.17
+  # ensure versions are strings!
+  SR_ANSIBLE_VER: "2.17"
   SR_REPO_NAME: kernel_settings
-  SR_PYTHON_VERSION: 3.12
+  SR_PYTHON_VERSION: "3.12"
   SR_ONLY_TESTS: ""  # tests_default.yml
   SR_TEST_LOCAL_CHANGES: true
   SR_PR_NUM: ""


### PR DESCRIPTION
The ansible version is specified as a YAML floating point number.  This causes
`2.20` to be converted to `2.2` which breaks platforms that use ansible 2.20.
Ensure it and similar version numbers are specified in YAML as strings.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Update GitHub Actions test matrix to specify Ansible versions as quoted strings across all platforms to avoid float conversion issues.