### PR TITLE
fix: ensure idempotence by writing settings in sorted order

### DIFF
--- a/templates/kernel_settings.j2
+++ b/templates/kernel_settings.j2
@@ -2,7 +2,8 @@
 {{ "system_role:kernel_settings" | comment(prefix="", postfix="") }}
 {% macro write_section(section_name, settings) %}
 [{{ section_name }}]
-{%   for key, val in settings.items() %}
+{%   for key in settings.keys() | sort %}
+{%     set val = settings[key] %}
 {%     if val != {"state": "absent"} %}
 {{ key }} = {{ val }}
 {%     endif %}


### PR DESCRIPTION
Cause: On EL7, the underlying module uses an unordered dict, so the order of the settings being
written can change between role invocations.

Consequence: The role may report changed when nothing actually changed except the order.

Fix: The settings are sorted before being written so that the order is consistent.

Result: The role does not report changed when nothing has changed.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Bug Fixes:
- Prevent spurious changes being reported by the role by sorting kernel settings before rendering them in the template.