### PR TITLE
test: ensure role gathers the facts it uses by having test clear_facts before include_role

### DIFF
--- a/tests/tasks/cleanup.yml
+++ b/tests/tasks/cleanup.yml
@@ -7,8 +7,7 @@
 - name: Use role purge to remove settings
   block:
     - name: Run role with purge to remove everything
-      include_role:
-        name: linux-system-roles.kernel_settings
+      include_tasks: tasks/run_role_with_clear_facts.yml
       vars:
         kernel_settings_purge: true
         kernel_settings_sysctl: []

--- a/tests/tasks/run_role_with_clear_facts.yml
+++ b/tests/tasks/run_role_with_clear_facts.yml
@@ -1,0 +1,37 @@
+---
+# Task file: clear_facts, run linux-system-roles.kernel_settings.
+# Include this with include_tasks or import_tasks
+# Input:
+# - __sr_tasks_from: tasks_from to run - same as tasks_from in include_role
+# - __sr_public: export private vars from role - same as public in include_role
+# - __sr_failed_when: set to false to ignore role errors - same as failed_when in include_role
+- name: Clear facts
+  meta: clear_facts
+
+# note that you can use failed_when with import_role but not with include_role
+# so this simulates the __sr_failed_when false case
+# Q: Why do we need a separate task to run the role normally?  Why not just
+# run the role in the block and rethrow the error in the rescue block?
+# A: Because you cannot rethrow the error in exactly the same way as the role does.
+# It might be possible to exactly reconstruct ansible_failed_result but it's not worth the effort.
+- name: Run the role with __sr_failed_when false
+  when:
+    - __sr_failed_when is defined
+    - not __sr_failed_when
+  block:
+    - name: Run the role
+      include_role:
+        name: linux-system-roles.kernel_settings
+        tasks_from: "{{ __sr_tasks_from | default('main') }}"
+        public: "{{ __sr_public | default(false) }}"
+  rescue:
+    - name: Ignore the failure when __sr_failed_when is false
+      debug:
+        msg: Ignoring failure when __sr_failed_when is false
+
+- name: Run the role normally
+  include_role:
+    name: linux-system-roles.kernel_settings
+    tasks_from: "{{ __sr_tasks_from | default('main') }}"
+    public: "{{ __sr_public | default(false) }}"
+  when: __sr_failed_when | d(true)

--- a/tests/tests_bool_not_allowed.yml
+++ b/tests/tests_bool_not_allowed.yml
@@ -5,10 +5,9 @@
     - name: Validate no boolean values for sysctl values
       block:
         - name: Try to pass a boolean value for sysctl value
-          include_role:
-            name: linux-system-roles.kernel_settings
-            public: true
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
+            __sr_public: true
             kernel_settings_sysctl:
               - name: valid_value
                 value: "true"

--- a/tests/tests_change_settings.yml
+++ b/tests/tests_change_settings.yml
@@ -58,10 +58,9 @@
             enabled: true
 
         - name: Apply kernel_settings
-          include_role:
-            name: linux-system-roles.kernel_settings
-            public: true
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
+            __sr_public: true
             kernel_settings_sysctl:
               - name: fs.file-max
                 value: 400000
@@ -120,8 +119,7 @@
           changed_when: false
 
         - name: Apply role again and remove settings
-          include_role:
-            name: linux-system-roles.kernel_settings
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             kernel_settings_reboot_ok: true
             kernel_settings_sysctl:
@@ -148,8 +146,7 @@
           changed_when: false
 
         - name: Apply kernel_settings for removing
-          include_role:
-            name: linux-system-roles.kernel_settings
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             kernel_settings_reboot_ok: true
             kernel_settings_sysctl:
@@ -181,8 +178,7 @@
           changed_when: false
 
         - name: Apply kernel_settings for removing section
-          include_role:
-            name: linux-system-roles.kernel_settings
+          include_tasks: tasks/run_role_with_clear_facts.yml
           vars:
             kernel_settings_reboot_ok: true
             kernel_settings_sysctl:

--- a/tests/tests_default.yml
+++ b/tests/tests_default.yml
@@ -1,14 +1,13 @@
 ---
 - name: Ensure that the role runs with default parameters
   hosts: all
-  gather_facts: false
   tasks:
     - name: Run test
       block:
         - name: Run role with no settings
-          include_role:
-            name: linux-system-roles.kernel_settings
-            public: true
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
 
       always:
         - name: Cleanup

--- a/tests/tests_include_vars_from_parent.yml
+++ b/tests/tests_include_vars_from_parent.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test role variable override
   hosts: all
-  gather_facts: true
   tasks:
     - name: Run test
       block:

--- a/tests/tests_simple_settings.yml
+++ b/tests/tests_simple_settings.yml
@@ -1,7 +1,6 @@
 ---
 - name: Test simple kernel settings
   hosts: all
-  gather_facts: true
   tags:
     - tests::reboot
   tasks:
@@ -23,9 +22,9 @@
         # __kernel_settings_profile_filename to verify
         # that the settings were applied correctly
         - name: Apply the settings - call the role
-          include_role:
-            name: linux-system-roles.kernel_settings
-            public: true
+          include_tasks: tasks/run_role_with_clear_facts.yml
+          vars:
+            __sr_public: true
 
         - name: Verify that settings were applied correctly
           include_tasks: tasks/assert_kernel_settings.yml
@@ -61,8 +60,7 @@
             - not kernel_settings_test_reboot_ok | d(false)
 
         - name: Apply the settings again to check idempotency
-          include_role:
-            name: linux-system-roles.kernel_settings
+          include_tasks: tasks/run_role_with_clear_facts.yml
 
         - name: Ensure role reported not changed
           assert:


### PR DESCRIPTION
The role gathers the facts it uses.  For example, if the user uses
`ANSIBLE_GATHERING=explicit`, the role uses the `setup` module with the
facts and subsets it requires.

This change allows us to test this.  Before every role invocation, the test
will use `meta: clear_facts` so that the role starts with no facts.

Create a task file tests/tasks/run_role_with_clear_facts.yml to do the tasks
to clear the facts and run the role.  Note that this means we don't need to
use `gather_facts` for the tests.

Some vars defined using `ansible_facts` have been changed to be defined with
`set_fact` instead.  This is because of the fact that `vars` are lazily
evaluated - the var might be referenced when the facts have been cleared, and
will issue an error like `ansible_facts["distribution"] is undefined`.  This is
typically done for blocks that have a `when` condition that uses `ansible_facts`
and the block has a role invocation using run_role_with_clear_facts.yml
These have been rewritten to define the `when` condition using `set_fact`.  This
is because the `when` condition is evaluated every time a task is invoked in the
block, and if the facts are cleared, this will raise an undefined variable error.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Ensure kernel_settings role tests run the role with cleared Ansible facts to verify it gathers required facts explicitly.

New Features:
- Add a reusable test task file to clear Ansible facts and invoke the kernel_settings role with configurable options.

Enhancements:
- Refactor existing kernel_settings tests to use a shared task file for invoking the role instead of including the role directly, removing explicit fact gathering from playbooks.