### PR TITLE
ci: fix yum repos to use devel site instead of old site name [citest_skip]

### DIFF
--- a/plans/test_playbooks_parallel.fmf
+++ b/plans/test_playbooks_parallel.fmf
@@ -32,6 +32,9 @@ prepare:
       if grep -q 'CentOS Linux release 7.9' /etc/redhat-release; then
         sed -i '/^mirror/d;s/#\?\(baseurl=http:\/\/\)mirror/\1vault/' /etc/yum.repos.d/*.repo
       fi
+  - name: Ensure use of devel site for yum repos
+    script: |
+      sed -i -e 's|\.lab\.bos\.|.devel.|g' -e 's|\.eng\.bos\.|.devel.|g' /etc/yum.repos.d/*.repo
 discover:
   - name: Prepare managed node
     how: fmf


### PR DESCRIPTION
Some of the older Testing Farm machines refer to the old site name in the yum repos.
Ensure that they use the correct site name.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

CI:
- Switch Testing Farm yum repository references from the old site name to the current devel site.