### PR TITLE
refactor: comply with Ansible partner certification checks

### DIFF
--- a/.sanity-ansible-ignore-2.18.txt
+++ b/.sanity-ansible-ignore-2.18.txt
@@ -1,0 +1,1 @@
+plugins/modules/kernel_settings_get_config.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.19.txt
+++ b/.sanity-ansible-ignore-2.19.txt
@@ -1,0 +1,1 @@
+plugins/modules/kernel_settings_get_config.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.20.txt
+++ b/.sanity-ansible-ignore-2.20.txt
@@ -1,0 +1,1 @@
+plugins/modules/kernel_settings_get_config.py validate-modules:missing-gplv3-license

--- a/.sanity-ansible-ignore-2.21.txt
+++ b/.sanity-ansible-ignore-2.21.txt
@@ -1,0 +1,1 @@
+plugins/modules/kernel_settings_get_config.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
prepare for testing with all supported and milestone ansible-test versions

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Build:
- Introduce .sanity-ansible-ignore configuration files for ansible-test versions 2.18 through 2.21 to align local checks with certification requirements.