### PR TITLE
test: support ansible-test milestone version 2.22 [citest_skip]

### DIFF
--- a/.sanity-ansible-ignore-2.22.txt
+++ b/.sanity-ansible-ignore-2.22.txt
@@ -1,0 +1,1 @@
+plugins/modules/kernel_settings_get_config.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
The ansible milestone branch is now version 2.22

Signed-off-by: Rich Megginson <rmeggins@redhat.com>

## Summary by Sourcery

Tests:
- Add a new Ansible sanity ignore configuration file for the 2.22 milestone version.